### PR TITLE
Switched order of permission and object calls

### DIFF
--- a/rules/contrib/views.py
+++ b/rules/contrib/views.py
@@ -46,8 +46,8 @@ class PermissionRequiredMixin(mixins.PermissionRequiredMixin):
             return None
 
     def has_permission(self):
-        obj = self.get_permission_object()
         perms = self.get_permission_required()
+        obj = self.get_permission_object()
         return self.request.user.has_perms(perms, obj)
 
 


### PR DESCRIPTION
In the class-based view mixin, the required permissions should be requested _before_ the permission object. The permission object might depend on the required permissions. The code in get_permission_required might e.g. set self.permission_object to dynamically determine the permission object.
